### PR TITLE
fix: python version 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ After installing you should already have the command available for usage. Run `n
 
 ## Development
 
-For creating new plugins follow this instructions below.
+For creating new plugins follow this instructions below. Please also ensure that you are using a python verion ```python3.7```.
 
 1. Install Poetry:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7.11"
+python = "~3.7.11"
 click = "^8.0.4"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Using ```python = "^3.7.11"``` would allow users to use a virtual environment with python version ```python3.x.x```.

Modifying it to ```python = "~3.7.11"``` can ensure that the user is using a python version ```python3.7```.

```type_ast``` which is a dependencies of ```cairo-nile``` has compatibility issue with some other python version, e.g. ```python3.9```.